### PR TITLE
Refine UI Aesthetics and Update Theme to Frappe

### DIFF
--- a/lua/vsubota/plugins/cmp.lua
+++ b/lua/vsubota/plugins/cmp.lua
@@ -35,8 +35,14 @@ return {
 					end,
 				},
 				window = {
-					completion = cmp.config.window.bordered(),
-					documentation = cmp.config.window.bordered(),
+					completion = {
+						border = "rounded",
+						winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+					},
+					documentation = {
+						border = "rounded",
+						winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+					},
 				},
 				mapping = cmp.mapping.preset.insert({
 					["<C-b>"] = cmp.mapping.scroll_docs(-4),

--- a/lua/vsubota/plugins/colors.lua
+++ b/lua/vsubota/plugins/colors.lua
@@ -18,6 +18,39 @@ return {
 					LspReferenceRead = { cterm = { bold = true }, ctermbg = 135, bg = colors.surface1 },
 					LspReferenceText = { cterm = { bold = true }, ctermbg = 135, bg = colors.surface1 },
 					LspReferenceWrite = { cterm = { bold = true }, ctermbg = 135, bg = colors.surface1 },
+					-- Dim inactive nvim splits
+					NormalNC = { bg = vim.o.background == "dark" and colors.mantle or colors.mantle },
+					-- Default floats (lighter — Harpoon, etc.)
+					NormalFloat = { bg = colors.base },
+					FloatBorder = { bg = colors.base, fg = colors.surface0 },
+					-- LSP hover/diagnostics (darker)
+					LspFloatNormal = { bg = colors.mantle },
+					LspFloatBorder = { bg = colors.mantle, fg = colors.surface1 },
+					-- Telescope (lighter)
+					TelescopeNormal = { bg = colors.base },
+					TelescopeBorder = { bg = colors.base, fg = colors.surface0 },
+					TelescopeTitle = { bg = colors.base, fg = colors.blue },
+					TelescopePromptNormal = { bg = colors.base },
+					TelescopePromptBorder = { bg = colors.base, fg = colors.surface0 },
+					TelescopePromptTitle = { bg = colors.base, fg = colors.blue },
+					TelescopeResultsNormal = { bg = colors.base },
+					TelescopeResultsBorder = { bg = colors.base, fg = colors.surface0 },
+					TelescopeResultsTitle = { bg = colors.base, fg = colors.blue },
+					TelescopePreviewNormal = { bg = colors.base },
+					TelescopePreviewBorder = { bg = colors.base, fg = colors.surface0 },
+					TelescopePreviewTitle = { bg = colors.base, fg = colors.blue },
+					-- Snacks picker (lighter)
+					SnacksPickerInput = { bg = colors.base },
+					SnacksPickerInputBorder = { bg = colors.base, fg = colors.surface0 },
+					SnacksPickerInputTitle = { bg = colors.base, fg = colors.blue },
+					SnacksPickerList = { bg = colors.base },
+					SnacksPickerListBorder = { bg = colors.base, fg = colors.surface0 },
+					SnacksPickerPreview = { bg = colors.base },
+					SnacksPickerPreviewBorder = { bg = colors.base, fg = colors.surface0 },
+					SnacksPickerPreviewTitle = { bg = colors.base, fg = colors.blue },
+					-- Plugin UIs (Lazy, Mason, etc.) — popup lighter, backdrop darker
+					LazyNormal = { bg = colors.base },
+					LazyBackdrop = { bg = colors.mantle },
 				}
 			end,
 

--- a/lua/vsubota/plugins/colors.lua
+++ b/lua/vsubota/plugins/colors.lua
@@ -8,8 +8,11 @@ return {
 				return {
 					LineNr = { fg = colors.overlay0 },
 					CursorLineNr = { fg = colors.sapphire },
-					CursorLine = { bg = vim.o.background == "dark" and "#3e4255" or colors.surface0 },
-					ColorColumn = { bg = vim.o.background == "dark" and "#3e4255" or colors.surface0 },
+					-- Frappe surface0 (uncomment below for Macchiato)
+					CursorLine = { bg = vim.o.background == "dark" and "#414559" or colors.surface0 },
+					ColorColumn = { bg = vim.o.background == "dark" and "#414559" or colors.surface0 },
+					-- CursorLine = { bg = vim.o.background == "dark" and "#3e4255" or colors.surface0 },
+					-- ColorColumn = { bg = vim.o.background == "dark" and "#3e4255" or colors.surface0 },
 					IblScope = { fg = colors.surface2 },
 					GitSignsAdd = { fg = colors.blue },
 					GitSignsChange = { fg = colors.yellow },
@@ -58,7 +61,8 @@ return {
 
 			background = {
 				light = "latte",
-				dark = "macchiato",
+				dark = "frappe",
+				-- dark = "macchiato",
 			},
 
 			integrations = {

--- a/lua/vsubota/plugins/lsp-config.lua
+++ b/lua/vsubota/plugins/lsp-config.lua
@@ -42,12 +42,13 @@ return {
 							end,
 						})
 					end, opts)
+					local lsp_winhighlight = "Normal:LspFloatNormal,FloatBorder:LspFloatBorder"
 					vim.keymap.set("n", "H", function()
-						vim.lsp.buf.hover({ border = "rounded" })
+						vim.lsp.buf.hover({ border = "rounded", winhighlight = lsp_winhighlight })
 					end, opts)
 					vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
 					vim.keymap.set({ "n", "i" }, "<C-g>", function()
-						vim.lsp.buf.signature_help({ border = "rounded" })
+						vim.lsp.buf.signature_help({ border = "rounded", winhighlight = lsp_winhighlight })
 					end, opts)
 					vim.keymap.set("n", "<space>wl", function()
 						print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
@@ -74,14 +75,15 @@ return {
 				end,
 			})
 
+			local diag_winhighlight = "Normal:LspFloatNormal,FloatBorder:LspFloatBorder"
 			vim.keymap.set("n", "<space>vd", function()
-				vim.diagnostic.open_float({ border = "rounded" })
+				vim.diagnostic.open_float({ border = "rounded", winhighlight = diag_winhighlight })
 			end)
 			vim.keymap.set("n", "[d", function()
-				vim.diagnostic.jump({ count = -1, float = { border = "rounded" } })
+				vim.diagnostic.jump({ count = -1, float = { border = "rounded", winhighlight = diag_winhighlight } })
 			end)
 			vim.keymap.set("n", "]d", function()
-				vim.diagnostic.jump({ count = 1, float = { border = "rounded" } })
+				vim.diagnostic.jump({ count = 1, float = { border = "rounded", winhighlight = diag_winhighlight } })
 			end)
 			vim.keymap.set("n", "<space>q", vim.diagnostic.setloclist)
 		end,

--- a/lua/vsubota/plugins/snacks-picker.lua
+++ b/lua/vsubota/plugins/snacks-picker.lua
@@ -133,6 +133,8 @@ return {
 					keys = {
 						["<C-j>"] = { "list_down", mode = { "i", "n" } },
 						["<C-k>"] = { "list_up", mode = { "i", "n" } },
+						["<C-d>"] = { "preview_scroll_down", mode = { "i", "n" } },
+						["<C-u>"] = { "preview_scroll_up", mode = { "i", "n" } },
 						["<C-f>"] = { "fuzzy_refine", mode = { "i", "n" }, desc = "Fuzzy refine results" },
 						["<C-q>"] = { "qflist", mode = { "i", "n" } },
 					},


### PR DESCRIPTION
  This PR updates the Catppuccin flavor to Frappe and introduces several UI refinements to improve visual
  consistency, focus, and navigation across the editor.

  Summary of Changes

   * Theme Update: Switched the dark flavor to Catppuccin Frappe and adjusted CursorLine and ColorColumn
     backgrounds to match the new palette.
   * UI Refinements:
       * Updated CMP and LSP floating windows (hover, signature help, diagnostics) to use rounded
         borders.
       * Implemented NormalNC highlights to subtly dim inactive splits, helping focus on the current
         buffer.
       * Customized background highlights for floating windows in Telescope, Snacks, and LSP to provide
         better contrast against the main editor.
   * Enhanced Keymaps: Added <C-d> and <C-u> to the Snacks picker for easier scrolling within the preview
     window.

  Components Affected

   * lua/vsubota/plugins/colors.lua: Theme configuration and global highlight overrides.
   * lua/vsubota/plugins/cmp.lua: Completion window styling.
   * lua/vsubota/plugins/lsp-config.lua: LSP floating window and diagnostic styling.
   * lua/vsubota/plugins/snacks-picker.lua: Navigation keymaps for the picker preview.
